### PR TITLE
chore: throw exceptions on missing commands

### DIFF
--- a/src/main/java/momento/lettuce/MomentoRedisReactiveClient.java
+++ b/src/main/java/momento/lettuce/MomentoRedisReactiveClient.java
@@ -126,267 +126,283 @@ public class MomentoRedisReactiveClient<K, V>
   }
 
   @Override
-  public void setTimeout(Duration duration) {}
+  public void setTimeout(Duration duration) {
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("setTimeout");
+  }
 
   @Override
   public Mono<String> asking() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("asking");
   }
 
   @Override
   public Mono<String> auth(CharSequence charSequence) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("auth");
   }
 
   @Override
   public Mono<String> auth(String s, CharSequence charSequence) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("auth");
   }
 
   @Override
   public Mono<String> clusterAddSlots(int... ints) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterAddSlots");
   }
 
   @Override
   public Mono<String> clusterBumpepoch() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterBumpepoch");
   }
 
   @Override
   public Mono<Long> clusterCountFailureReports(String s) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "clusterCountFailureReports");
   }
 
   @Override
   public Mono<Long> clusterCountKeysInSlot(int i) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "clusterCountKeysInSlot");
   }
 
   @Override
   public Mono<String> clusterAddSlotsRange(Range<Integer>... ranges) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "clusterAddSlotsRange");
   }
 
   @Override
   public Mono<String> clusterDelSlots(int... ints) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterDelSlots");
   }
 
   @Override
   public Mono<String> clusterDelSlotsRange(Range<Integer>... ranges) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "clusterDelSlotsRange");
   }
 
   @Override
   public Mono<String> clusterFailover(boolean b) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterFailover");
   }
 
   @Override
   public Mono<String> clusterFailover(boolean b, boolean b1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterFailover");
   }
 
   @Override
   public Mono<String> clusterFlushslots() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterFlushslots");
   }
 
   @Override
   public Mono<String> clusterForget(String s) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterForget");
   }
 
   @Override
   public Flux<K> clusterGetKeysInSlot(int i, int i1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "clusterGetKeysInSlot");
   }
 
   @Override
   public Mono<String> clusterInfo() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterInfo");
   }
 
   @Override
   public Mono<Long> clusterKeyslot(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterKeyslot");
   }
 
   @Override
   public Mono<String> clusterMeet(String s, int i) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterMeet");
   }
 
   @Override
   public Mono<String> clusterMyId() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterMyId");
   }
 
   @Override
   public Mono<String> clusterNodes() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterNodes");
   }
 
   @Override
   public Mono<String> clusterReplicate(String s) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterReplicate");
   }
 
   @Override
   public Flux<String> clusterReplicas(String s) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterReplicas");
   }
 
   @Override
   public Mono<String> clusterReset(boolean b) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterReset");
   }
 
   @Override
   public Mono<String> clusterSaveconfig() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterSaveconfig");
   }
 
   @Override
   public Mono<String> clusterSetConfigEpoch(long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "clusterSetConfigEpoch");
   }
 
   @Override
   public Mono<String> clusterSetSlotImporting(int i, String s) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "clusterSetSlotImporting");
   }
 
   @Override
   public Mono<String> clusterSetSlotMigrating(int i, String s) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "clusterSetSlotMigrating");
   }
 
   @Override
   public Mono<String> clusterSetSlotNode(int i, String s) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "clusterSetSlotNode");
   }
 
   @Override
   public Mono<String> clusterSetSlotStable(int i) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "clusterSetSlotStable");
   }
 
   @Override
   public Mono<List<Object>> clusterShards() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterShards");
   }
 
   @Override
   public Flux<String> clusterSlaves(String s) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterSlaves");
   }
 
   @Override
   public Flux<Object> clusterSlots() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clusterSlots");
   }
 
   @Override
   public Mono<String> select(int i) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("select");
   }
 
   @Override
   public Mono<String> swapdb(int i, int i1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("swapdb");
   }
 
   @Override
   public StatefulRedisConnection<K, V> getStatefulConnection() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "getStatefulConnection");
   }
 
   @Override
   public Mono<Long> publish(K k, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("publish");
   }
 
   @Override
   public Flux<K> pubsubChannels() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("pubsubChannels");
   }
 
   @Override
   public Flux<K> pubsubChannels(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("pubsubChannels");
   }
 
   @Override
   public Mono<Map<K, Long>> pubsubNumsub(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("pubsubNumsub");
   }
 
   @Override
   public Flux<K> pubsubShardChannels() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "pubsubShardChannels");
   }
 
   @Override
   public Flux<K> pubsubShardChannels(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "pubsubShardChannels");
   }
 
   @Override
   public Mono<Map<K, Long>> pubsubShardNumsub(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("Long");
   }
 
   @Override
   public Mono<Long> pubsubNumpat() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("pubsubNumpat");
   }
 
   @Override
   public Mono<Long> spublish(K k, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("spublish");
   }
 
   @Override
   public Mono<V> echo(V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("echo");
   }
 
   @Override
   public Flux<Object> role() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("role");
   }
 
   @Override
   public Mono<String> ping() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("ping");
   }
 
   @Override
   public Mono<String> readOnly() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("readOnly");
   }
 
   @Override
   public Mono<String> readWrite() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("readWrite");
   }
 
   @Override
   public Mono<String> quit() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("quit");
   }
 
   @Override
   public Mono<Long> waitForReplication(int i, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "waitForReplication");
   }
 
   @Override
   public <T> Flux<T> dispatch(
       ProtocolKeyword protocolKeyword, CommandOutput<K, V, ?> commandOutput) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("dispatch");
   }
 
   @Override
@@ -394,7 +410,7 @@ public class MomentoRedisReactiveClient<K, V>
       ProtocolKeyword protocolKeyword,
       CommandOutput<K, V, ?> commandOutput,
       CommandArgs<K, V> commandArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("dispatch");
   }
 
   @Override
@@ -413,208 +429,208 @@ public class MomentoRedisReactiveClient<K, V>
 
   @Override
   public Mono<Set<AclCategory>> aclCat() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclCat");
   }
 
   @Override
   public Mono<Set<CommandType>> aclCat(AclCategory aclCategory) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclCat");
   }
 
   @Override
   public Mono<Long> aclDeluser(String... strings) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclDeluser");
   }
 
   @Override
   public Mono<String> aclDryRun(String s, String s1, String... strings) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclDryRun");
   }
 
   @Override
   public Mono<String> aclDryRun(String s, RedisCommand<K, V, ?> redisCommand) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclDryRun");
   }
 
   @Override
   public Mono<String> aclGenpass() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclGenpass");
   }
 
   @Override
   public Mono<String> aclGenpass(int i) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclGenpass");
   }
 
   @Override
   public Mono<List<Object>> aclGetuser(String s) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclGetuser");
   }
 
   @Override
   public Flux<String> aclList() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclList");
   }
 
   @Override
   public Mono<String> aclLoad() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclLoad");
   }
 
   @Override
   public Flux<Map<String, Object>> aclLog() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclLog");
   }
 
   @Override
   public Flux<Map<String, Object>> aclLog(int i) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclLog");
   }
 
   @Override
   public Mono<String> aclLogReset() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclLogReset");
   }
 
   @Override
   public Mono<String> aclSave() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclSave");
   }
 
   @Override
   public Mono<String> aclSetuser(String s, AclSetuserArgs aclSetuserArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclSetuser");
   }
 
   @Override
   public Flux<String> aclUsers() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclUsers");
   }
 
   @Override
   public Mono<String> aclWhoami() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("aclWhoami");
   }
 
   @Override
   public <T> Flux<T> fcall(String s, ScriptOutputType scriptOutputType, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("fcall");
   }
 
   @Override
   public <T> Flux<T> fcall(String s, ScriptOutputType scriptOutputType, K[] ks, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("fcall");
   }
 
   @Override
   public <T> Flux<T> fcallReadOnly(String s, ScriptOutputType scriptOutputType, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("fcallReadOnly");
   }
 
   @Override
   public <T> Flux<T> fcallReadOnly(String s, ScriptOutputType scriptOutputType, K[] ks, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("fcallReadOnly");
   }
 
   @Override
   public Mono<String> functionLoad(String s) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("functionLoad");
   }
 
   @Override
   public Mono<String> functionLoad(String s, boolean b) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("functionLoad");
   }
 
   @Override
   public Mono<byte[]> functionDump() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("functionDump");
   }
 
   @Override
   public Mono<String> functionRestore(byte[] bytes) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("functionRestore");
   }
 
   @Override
   public Mono<String> functionRestore(byte[] bytes, FunctionRestoreMode functionRestoreMode) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("functionRestore");
   }
 
   @Override
   public Mono<String> functionFlush(FlushMode flushMode) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("functionFlush");
   }
 
   @Override
   public Mono<String> functionKill() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("functionKill");
   }
 
   @Override
   public Flux<Map<String, Object>> functionList() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("functionList");
   }
 
   @Override
   public Flux<Map<String, Object>> functionList(String s) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("functionList");
   }
 
   @Override
   public Mono<Long> geoadd(K k, double v, double v1, V v2) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("geoadd");
   }
 
   @Override
   public Mono<Long> geoadd(K k, double v, double v1, V v2, GeoAddArgs geoAddArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("geoadd");
   }
 
   @Override
   public Mono<Long> geoadd(K k, Object... objects) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("geoadd");
   }
 
   @Override
   public Mono<Long> geoadd(K k, GeoValue<V>... geoValues) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("geoadd");
   }
 
   @Override
   public Mono<Long> geoadd(K k, GeoAddArgs geoAddArgs, Object... objects) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("geoadd");
   }
 
   @Override
   public Mono<Long> geoadd(K k, GeoAddArgs geoAddArgs, GeoValue<V>... geoValues) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("geoadd");
   }
 
   @Override
   public Mono<Double> geodist(K k, V v, V v1, GeoArgs.Unit unit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("geodist");
   }
 
   @Override
   public Flux<Value<String>> geohash(K k, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("geohash");
   }
 
   @Override
   public Flux<Value<GeoCoordinates>> geopos(K k, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("geopos");
   }
 
   @Override
   public Flux<V> georadius(K k, double v, double v1, double v2, GeoArgs.Unit unit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("georadius");
   }
 
   @Override
   public Flux<GeoWithin<V>> georadius(
       K k, double v, double v1, double v2, GeoArgs.Unit unit, GeoArgs geoArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("georadius");
   }
 
   @Override
@@ -625,35 +641,35 @@ public class MomentoRedisReactiveClient<K, V>
       double v2,
       GeoArgs.Unit unit,
       GeoRadiusStoreArgs<K> geoRadiusStoreArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("georadius");
   }
 
   @Override
   public Flux<V> georadiusbymember(K k, V v, double v1, GeoArgs.Unit unit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("georadiusbymember");
   }
 
   @Override
   public Flux<GeoWithin<V>> georadiusbymember(
       K k, V v, double v1, GeoArgs.Unit unit, GeoArgs geoArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("georadiusbymember");
   }
 
   @Override
   public Mono<Long> georadiusbymember(
       K k, V v, double v1, GeoArgs.Unit unit, GeoRadiusStoreArgs<K> geoRadiusStoreArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("georadiusbymember");
   }
 
   @Override
   public Flux<V> geosearch(K k, GeoSearch.GeoRef<K> geoRef, GeoSearch.GeoPredicate geoPredicate) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("geosearch");
   }
 
   @Override
   public Flux<GeoWithin<V>> geosearch(
       K k, GeoSearch.GeoRef<K> geoRef, GeoSearch.GeoPredicate geoPredicate, GeoArgs geoArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("geosearch");
   }
 
   @Override
@@ -664,170 +680,172 @@ public class MomentoRedisReactiveClient<K, V>
       GeoSearch.GeoPredicate geoPredicate,
       GeoArgs geoArgs,
       boolean b) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("geosearchstore");
   }
 
   @Override
   public Mono<Long> pfadd(K k, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("pfadd");
   }
 
   @Override
   public Mono<String> pfmerge(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("pfmerge");
   }
 
   @Override
   public Mono<Long> pfcount(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("pfcount");
   }
 
   @Override
   public Mono<Long> hdel(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hdel");
   }
 
   @Override
   public Mono<Boolean> hexists(K k, K k1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hexists");
   }
 
   @Override
   public Mono<V> hget(K k, K k1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hget");
   }
 
   @Override
   public Mono<Long> hincrby(K k, K k1, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hincrby");
   }
 
   @Override
   public Mono<Double> hincrbyfloat(K k, K k1, double v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hincrbyfloat");
   }
 
   @Override
   public Flux<KeyValue<K, V>> hgetall(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hgetall");
   }
 
   @Override
   public Mono<Long> hgetall(KeyValueStreamingChannel<K, V> keyValueStreamingChannel, K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hgetall");
   }
 
   @Override
   public Flux<K> hkeys(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hkeys");
   }
 
   @Override
   public Mono<Long> hkeys(KeyStreamingChannel<K> keyStreamingChannel, K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hkeys");
   }
 
   @Override
   public Mono<Long> hlen(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hlen");
   }
 
   @Override
   public Flux<KeyValue<K, V>> hmget(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hmget");
   }
 
   @Override
   public Mono<Long> hmget(KeyValueStreamingChannel<K, V> keyValueStreamingChannel, K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hmget");
   }
 
   @Override
   public Mono<String> hmset(K k, Map<K, V> map) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hmset");
   }
 
   @Override
   public Mono<K> hrandfield(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hrandfield");
   }
 
   @Override
   public Flux<K> hrandfield(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hrandfield");
   }
 
   @Override
   public Mono<KeyValue<K, V>> hrandfieldWithvalues(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "hrandfieldWithvalues");
   }
 
   @Override
   public Flux<KeyValue<K, V>> hrandfieldWithvalues(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "hrandfieldWithvalues");
   }
 
   @Override
   public Mono<MapScanCursor<K, V>> hscan(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hscan");
   }
 
   @Override
   public Mono<KeyScanCursor<K>> hscanNovalues(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hscanNovalues");
   }
 
   @Override
   public Mono<MapScanCursor<K, V>> hscan(K k, ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hscan");
   }
 
   @Override
   public Mono<KeyScanCursor<K>> hscanNovalues(K k, ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hscanNovalues");
   }
 
   @Override
   public Mono<MapScanCursor<K, V>> hscan(K k, ScanCursor scanCursor, ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hscan");
   }
 
   @Override
   public Mono<KeyScanCursor<K>> hscanNovalues(K k, ScanCursor scanCursor, ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hscanNovalues");
   }
 
   @Override
   public Mono<MapScanCursor<K, V>> hscan(K k, ScanCursor scanCursor) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hscan");
   }
 
   @Override
   public Mono<KeyScanCursor<K>> hscanNovalues(K k, ScanCursor scanCursor) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hscanNovalues");
   }
 
   @Override
   public Mono<StreamScanCursor> hscan(
       KeyValueStreamingChannel<K, V> keyValueStreamingChannel, K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hscan");
   }
 
   @Override
   public Mono<StreamScanCursor> hscanNovalues(KeyStreamingChannel<K> keyStreamingChannel, K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hscanNovalues");
   }
 
   @Override
   public Mono<StreamScanCursor> hscan(
       KeyValueStreamingChannel<K, V> keyValueStreamingChannel, K k, ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hscan");
   }
 
   @Override
   public Mono<StreamScanCursor> hscanNovalues(
       KeyStreamingChannel<K> keyStreamingChannel, K k, ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hscanNovalues");
   }
 
   @Override
@@ -836,195 +854,195 @@ public class MomentoRedisReactiveClient<K, V>
       K k,
       ScanCursor scanCursor,
       ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hscan");
   }
 
   @Override
   public Mono<StreamScanCursor> hscanNovalues(
       KeyStreamingChannel<K> keyStreamingChannel, K k, ScanCursor scanCursor, ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hscanNovalues");
   }
 
   @Override
   public Mono<StreamScanCursor> hscan(
       KeyValueStreamingChannel<K, V> keyValueStreamingChannel, K k, ScanCursor scanCursor) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hscan");
   }
 
   @Override
   public Mono<StreamScanCursor> hscanNovalues(
       KeyStreamingChannel<K> keyStreamingChannel, K k, ScanCursor scanCursor) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hscanNovalues");
   }
 
   @Override
   public Mono<Boolean> hset(K k, K k1, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hset");
   }
 
   @Override
   public Mono<Long> hset(K k, Map<K, V> map) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hset");
   }
 
   @Override
   public Mono<Boolean> hsetnx(K k, K k1, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hsetnx");
   }
 
   @Override
   public Mono<Long> hstrlen(K k, K k1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hstrlen");
   }
 
   @Override
   public Flux<V> hvals(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hvals");
   }
 
   @Override
   public Mono<Long> hvals(ValueStreamingChannel<V> valueStreamingChannel, K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hvals");
   }
 
   @Override
   public Flux<Long> hexpire(K k, long l, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hexpire");
   }
 
   @Override
   public Flux<Long> hexpire(K k, long l, ExpireArgs expireArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hexpire");
   }
 
   @Override
   public Flux<Long> hexpire(K k, Duration duration, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hexpire");
   }
 
   @Override
   public Flux<Long> hexpire(K k, Duration duration, ExpireArgs expireArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hexpire");
   }
 
   @Override
   public Flux<Long> hexpireat(K k, long l, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hexpireat");
   }
 
   @Override
   public Flux<Long> hexpireat(K k, long l, ExpireArgs expireArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hexpireat");
   }
 
   @Override
   public Flux<Long> hexpireat(K k, Date date, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hexpireat");
   }
 
   @Override
   public Flux<Long> hexpireat(K k, Date date, ExpireArgs expireArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hexpireat");
   }
 
   @Override
   public Flux<Long> hexpireat(K k, Instant instant, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hexpireat");
   }
 
   @Override
   public Flux<Long> hexpireat(K k, Instant instant, ExpireArgs expireArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hexpireat");
   }
 
   @Override
   public Flux<Long> hexpiretime(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hexpiretime");
   }
 
   @Override
   public Flux<Long> hpersist(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hpersist");
   }
 
   @Override
   public Flux<Long> hpexpire(K k, long l, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hpexpire");
   }
 
   @Override
   public Flux<Long> hpexpire(K k, long l, ExpireArgs expireArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hpexpire");
   }
 
   @Override
   public Flux<Long> hpexpire(K k, Duration duration, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hpexpire");
   }
 
   @Override
   public Flux<Long> hpexpire(K k, Duration duration, ExpireArgs expireArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hpexpire");
   }
 
   @Override
   public Flux<Long> hpexpireat(K k, long l, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hpexpireat");
   }
 
   @Override
   public Flux<Long> hpexpireat(K k, long l, ExpireArgs expireArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hpexpireat");
   }
 
   @Override
   public Flux<Long> hpexpireat(K k, Date date, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hpexpireat");
   }
 
   @Override
   public Flux<Long> hpexpireat(K k, Date date, ExpireArgs expireArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hpexpireat");
   }
 
   @Override
   public Flux<Long> hpexpireat(K k, Instant instant, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hpexpireat");
   }
 
   @Override
   public Flux<Long> hpexpireat(K k, Instant instant, ExpireArgs expireArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hpexpireat");
   }
 
   @Override
   public Flux<Long> hpexpiretime(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hpexpiretime");
   }
 
   @Override
   public Flux<Long> httl(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("httl");
   }
 
   @Override
   public Flux<Long> hpttl(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("hpttl");
   }
 
   @Override
   public Mono<Boolean> copy(K k, K k1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("copy");
   }
 
   @Override
   public Mono<Boolean> copy(K k, K k1, CopyArgs copyArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("copy");
   }
 
   @Override
   public Mono<Long> del(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("del");
   }
 
   @Override
@@ -1060,117 +1078,117 @@ public class MomentoRedisReactiveClient<K, V>
 
   @Override
   public Mono<byte[]> dump(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("dump");
   }
 
   @Override
   public Mono<Long> exists(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("exists");
   }
 
   @Override
   public Mono<Boolean> expire(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("expire");
   }
 
   @Override
   public Mono<Boolean> expire(K k, long l, ExpireArgs expireArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("expire");
   }
 
   @Override
   public Mono<Boolean> expire(K k, Duration duration) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("expire");
   }
 
   @Override
   public Mono<Boolean> expire(K k, Duration duration, ExpireArgs expireArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("expire");
   }
 
   @Override
   public Mono<Boolean> expireat(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("expireat");
   }
 
   @Override
   public Mono<Boolean> expireat(K k, long l, ExpireArgs expireArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("expireat");
   }
 
   @Override
   public Mono<Boolean> expireat(K k, Date date) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("expireat");
   }
 
   @Override
   public Mono<Boolean> expireat(K k, Date date, ExpireArgs expireArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("expireat");
   }
 
   @Override
   public Mono<Boolean> expireat(K k, Instant instant) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("expireat");
   }
 
   @Override
   public Mono<Boolean> expireat(K k, Instant instant, ExpireArgs expireArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("expireat");
   }
 
   @Override
   public Mono<Long> expiretime(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("expiretime");
   }
 
   @Override
   public Flux<K> keys(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("keys");
   }
 
   @Override
   public Mono<Long> keys(KeyStreamingChannel<K> keyStreamingChannel, K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("keys");
   }
 
   @Override
   public Mono<String> migrate(String s, int i, K k, int i1, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("migrate");
   }
 
   @Override
   public Mono<String> migrate(String s, int i, int i1, long l, MigrateArgs<K> migrateArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("migrate");
   }
 
   @Override
   public Mono<Boolean> move(K k, int i) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("move");
   }
 
   @Override
   public Mono<String> objectEncoding(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("objectEncoding");
   }
 
   @Override
   public Mono<Long> objectFreq(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("objectFreq");
   }
 
   @Override
   public Mono<Long> objectIdletime(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("objectIdletime");
   }
 
   @Override
   public Mono<Long> objectRefcount(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("objectRefcount");
   }
 
   @Override
   public Mono<Boolean> persist(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("persist");
   }
 
   @Override
@@ -1225,276 +1243,276 @@ public class MomentoRedisReactiveClient<K, V>
 
   @Override
   public Mono<Boolean> pexpireat(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("pexpireat");
   }
 
   @Override
   public Mono<Boolean> pexpireat(K k, long l, ExpireArgs expireArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("pexpireat");
   }
 
   @Override
   public Mono<Boolean> pexpireat(K k, Date date) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("pexpireat");
   }
 
   @Override
   public Mono<Boolean> pexpireat(K k, Date date, ExpireArgs expireArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("pexpireat");
   }
 
   @Override
   public Mono<Boolean> pexpireat(K k, Instant instant) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("pexpireat");
   }
 
   @Override
   public Mono<Boolean> pexpireat(K k, Instant instant, ExpireArgs expireArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("pexpireat");
   }
 
   @Override
   public Mono<Long> pexpiretime(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("pexpiretime");
   }
 
   @Override
   public Mono<Long> pttl(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("pttl");
   }
 
   @Override
   public Mono<K> randomkey() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("randomkey");
   }
 
   @Override
   public Mono<String> rename(K k, K k1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("rename");
   }
 
   @Override
   public Mono<Boolean> renamenx(K k, K k1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("renamenx");
   }
 
   @Override
   public Mono<String> restore(K k, long l, byte[] bytes) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("restore");
   }
 
   @Override
   public Mono<String> restore(K k, byte[] bytes, RestoreArgs restoreArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("restore");
   }
 
   @Override
   public Flux<V> sort(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sort");
   }
 
   @Override
   public Mono<Long> sort(ValueStreamingChannel<V> valueStreamingChannel, K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sort");
   }
 
   @Override
   public Flux<V> sort(K k, SortArgs sortArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sort");
   }
 
   @Override
   public Mono<Long> sort(ValueStreamingChannel<V> valueStreamingChannel, K k, SortArgs sortArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sort");
   }
 
   @Override
   public Flux<V> sortReadOnly(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sortReadOnly");
   }
 
   @Override
   public Mono<Long> sortReadOnly(ValueStreamingChannel<V> valueStreamingChannel, K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sortReadOnly");
   }
 
   @Override
   public Flux<V> sortReadOnly(K k, SortArgs sortArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sortReadOnly");
   }
 
   @Override
   public Mono<Long> sortReadOnly(
       ValueStreamingChannel<V> valueStreamingChannel, K k, SortArgs sortArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sortReadOnly");
   }
 
   @Override
   public Mono<Long> sortStore(K k, SortArgs sortArgs, K k1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sortStore");
   }
 
   @Override
   public Mono<Long> touch(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("touch");
   }
 
   @Override
   public Mono<Long> ttl(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("ttl");
   }
 
   @Override
   public Mono<String> type(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("type");
   }
 
   @Override
   public Mono<KeyScanCursor<K>> scan() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("scan");
   }
 
   @Override
   public Mono<KeyScanCursor<K>> scan(ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("scan");
   }
 
   @Override
   public Mono<KeyScanCursor<K>> scan(ScanCursor scanCursor, ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("scan");
   }
 
   @Override
   public Mono<KeyScanCursor<K>> scan(ScanCursor scanCursor) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("scan");
   }
 
   @Override
   public Mono<StreamScanCursor> scan(KeyStreamingChannel<K> keyStreamingChannel) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("scan");
   }
 
   @Override
   public Mono<StreamScanCursor> scan(
       KeyStreamingChannel<K> keyStreamingChannel, ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("scan");
   }
 
   @Override
   public Mono<StreamScanCursor> scan(
       KeyStreamingChannel<K> keyStreamingChannel, ScanCursor scanCursor, ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("scan");
   }
 
   @Override
   public Mono<StreamScanCursor> scan(
       KeyStreamingChannel<K> keyStreamingChannel, ScanCursor scanCursor) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("scan");
   }
 
   @Override
   public Mono<V> blmove(K k, K k1, LMoveArgs lMoveArgs, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("blmove");
   }
 
   @Override
   public Mono<V> blmove(K k, K k1, LMoveArgs lMoveArgs, double v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("blmove");
   }
 
   @Override
   public Mono<KeyValue<K, List<V>>> blmpop(long l, LMPopArgs lmPopArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("blmpop");
   }
 
   @Override
   public Mono<KeyValue<K, List<V>>> blmpop(double v, LMPopArgs lmPopArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("blmpop");
   }
 
   @Override
   public Mono<KeyValue<K, V>> blpop(long l, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("blpop");
   }
 
   @Override
   public Mono<KeyValue<K, V>> blpop(double v, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("blpop");
   }
 
   @Override
   public Mono<KeyValue<K, V>> brpop(long l, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("brpop");
   }
 
   @Override
   public Mono<KeyValue<K, V>> brpop(double v, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("brpop");
   }
 
   @Override
   public Mono<V> brpoplpush(long l, K k, K k1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("brpoplpush");
   }
 
   @Override
   public Mono<V> brpoplpush(double v, K k, K k1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("brpoplpush");
   }
 
   @Override
   public Mono<V> lindex(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("lindex");
   }
 
   @Override
   public Mono<Long> linsert(K k, boolean b, V v, V v1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("linsert");
   }
 
   @Override
   public Mono<Long> llen(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("llen");
   }
 
   @Override
   public Mono<V> lmove(K k, K k1, LMoveArgs lMoveArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("lmove");
   }
 
   @Override
   public Mono<KeyValue<K, List<V>>> lmpop(LMPopArgs lmPopArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("lmpop");
   }
 
   @Override
   public Mono<V> lpop(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("lpop");
   }
 
   @Override
   public Flux<V> lpop(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("lpop");
   }
 
   @Override
   public Mono<Long> lpos(K k, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("lpos");
   }
 
   @Override
   public Mono<Long> lpos(K k, V v, LPosArgs lPosArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("lpos");
   }
 
   @Override
   public Flux<Long> lpos(K k, V v, int i) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("lpos");
   }
 
   @Override
   public Flux<Long> lpos(K k, V v, int i, LPosArgs lPosArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("lpos");
   }
 
   @Override
@@ -1526,7 +1544,7 @@ public class MomentoRedisReactiveClient<K, V>
 
   @Override
   public Mono<Long> lpushx(K k, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("lpushx");
   }
 
   @Override
@@ -1563,17 +1581,17 @@ public class MomentoRedisReactiveClient<K, V>
 
   @Override
   public Mono<Long> lrange(ValueStreamingChannel<V> valueStreamingChannel, K k, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("lrange");
   }
 
   @Override
   public Mono<Long> lrem(K k, long l, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("lrem");
   }
 
   @Override
   public Mono<String> lset(K k, long l, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("lset");
   }
 
   @Override
@@ -1607,554 +1625,555 @@ public class MomentoRedisReactiveClient<K, V>
 
   @Override
   public Mono<V> rpop(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("rpop");
   }
 
   @Override
   public Flux<V> rpop(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("rpop");
   }
 
   @Override
   public Mono<V> rpoplpush(K k, K k1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("rpoplpush");
   }
 
   @Override
   public Mono<Long> rpush(K k, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("rpush");
   }
 
   @Override
   public Mono<Long> rpushx(K k, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("rpushx");
   }
 
   @Override
   public <T> Flux<T> eval(String s, ScriptOutputType scriptOutputType, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("eval");
   }
 
   @Override
   public <T> Flux<T> eval(byte[] bytes, ScriptOutputType scriptOutputType, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("eval");
   }
 
   @Override
   public <T> Flux<T> eval(String s, ScriptOutputType scriptOutputType, K[] ks, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("eval");
   }
 
   @Override
   public <T> Flux<T> eval(byte[] bytes, ScriptOutputType scriptOutputType, K[] ks, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("eval");
   }
 
   @Override
   public <T> Flux<T> evalReadOnly(String s, ScriptOutputType scriptOutputType, K[] ks, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("evalReadOnly");
   }
 
   @Override
   public <T> Flux<T> evalReadOnly(
       byte[] bytes, ScriptOutputType scriptOutputType, K[] ks, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("evalReadOnly");
   }
 
   @Override
   public <T> Flux<T> evalsha(String s, ScriptOutputType scriptOutputType, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("evalsha");
   }
 
   @Override
   public <T> Flux<T> evalsha(String s, ScriptOutputType scriptOutputType, K[] ks, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("evalsha");
   }
 
   @Override
   public <T> Flux<T> evalshaReadOnly(String s, ScriptOutputType scriptOutputType, K[] ks, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("evalshaReadOnly");
   }
 
   @Override
   public Flux<Boolean> scriptExists(String... strings) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("scriptExists");
   }
 
   @Override
   public Mono<String> scriptFlush() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("scriptFlush");
   }
 
   @Override
   public Mono<String> scriptFlush(FlushMode flushMode) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("scriptFlush");
   }
 
   @Override
   public Mono<String> scriptKill() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("scriptKill");
   }
 
   @Override
   public Mono<String> scriptLoad(String s) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("scriptLoad");
   }
 
   @Override
   public Mono<String> scriptLoad(byte[] bytes) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("scriptLoad");
   }
 
   @Override
   public String digest(String s) {
-    return "";
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("digest");
   }
 
   @Override
   public String digest(byte[] bytes) {
-    return "";
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("digest");
   }
 
   @Override
   public Mono<String> bgrewriteaof() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bgrewriteaof");
   }
 
   @Override
   public Mono<String> bgsave() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bgsave");
   }
 
   @Override
   public Mono<String> clientCaching(boolean b) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clientCaching");
   }
 
   @Override
   public Mono<K> clientGetname() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clientGetname");
   }
 
   @Override
   public Mono<Long> clientGetredir() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clientGetredir");
   }
 
   @Override
   public Mono<Long> clientId() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clientId");
   }
 
   @Override
   public Mono<String> clientKill(String s) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clientKill");
   }
 
   @Override
   public Mono<Long> clientKill(KillArgs killArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clientKill");
   }
 
   @Override
   public Mono<String> clientList() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clientList");
   }
 
   @Override
   public Mono<String> clientList(ClientListArgs clientListArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clientList");
   }
 
   @Override
   public Mono<String> clientInfo() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clientInfo");
   }
 
   @Override
   public Mono<String> clientNoEvict(boolean b) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clientNoEvict");
   }
 
   @Override
   public Mono<String> clientPause(long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clientPause");
   }
 
   @Override
   public Mono<String> clientSetname(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clientSetname");
   }
 
   @Override
   public Mono<String> clientSetinfo(String s, String s1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clientSetinfo");
   }
 
   @Override
   public Mono<String> clientTracking(TrackingArgs trackingArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clientTracking");
   }
 
   @Override
   public Mono<Long> clientUnblock(long l, UnblockType unblockType) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("clientUnblock");
   }
 
   @Override
   public Flux<Object> command() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("command");
   }
 
   @Override
   public Mono<Long> commandCount() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("commandCount");
   }
 
   @Override
   public Flux<Object> commandInfo(String... strings) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("commandInfo");
   }
 
   @Override
   public Flux<Object> commandInfo(CommandType... commandTypes) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("commandInfo");
   }
 
   @Override
   public Mono<Map<String, String>> configGet(String s) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("String");
   }
 
   @Override
   public Mono<Map<String, String>> configGet(String... strings) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("String");
   }
 
   @Override
   public Mono<String> configResetstat() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("configResetstat");
   }
 
   @Override
   public Mono<String> configRewrite() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("configRewrite");
   }
 
   @Override
   public Mono<String> configSet(String s, String s1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("configSet");
   }
 
   @Override
   public Mono<String> configSet(Map<String, String> map) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("configSet");
   }
 
   @Override
   public Mono<Long> dbsize() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("dbsize");
   }
 
   @Override
   public Mono<String> debugCrashAndRecover(Long aLong) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "debugCrashAndRecover");
   }
 
   @Override
   public Mono<String> debugHtstats(int i) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("debugHtstats");
   }
 
   @Override
   public Mono<String> debugObject(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("debugObject");
   }
 
   @Override
   public Mono<Void> debugOom() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("debugOom");
   }
 
   @Override
   public Mono<String> debugReload() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("debugReload");
   }
 
   @Override
   public Mono<String> debugRestart(Long aLong) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("debugRestart");
   }
 
   @Override
   public Mono<String> debugSdslen(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("debugSdslen");
   }
 
   @Override
   public Mono<Void> debugSegfault() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("debugSegfault");
   }
 
   @Override
   public Mono<String> flushall() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("flushall");
   }
 
   @Override
   public Mono<String> flushall(FlushMode flushMode) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("flushall");
   }
 
   @Override
   public Mono<String> flushallAsync() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("flushallAsync");
   }
 
   @Override
   public Mono<String> flushdb() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("flushdb");
   }
 
   @Override
   public Mono<String> flushdb(FlushMode flushMode) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("flushdb");
   }
 
   @Override
   public Mono<String> flushdbAsync() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("flushdbAsync");
   }
 
   @Override
   public Mono<String> info() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("info");
   }
 
   @Override
   public Mono<String> info(String s) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("info");
   }
 
   @Override
   public Mono<Date> lastsave() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("lastsave");
   }
 
   @Override
   public Mono<Long> memoryUsage(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("memoryUsage");
   }
 
   @Override
   public Mono<String> replicaof(String s, int i) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("replicaof");
   }
 
   @Override
   public Mono<String> replicaofNoOne() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("replicaofNoOne");
   }
 
   @Override
   public Mono<String> save() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("save");
   }
 
   @Override
   public Mono<Void> shutdown(boolean b) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("shutdown");
   }
 
   @Override
   public Mono<Void> shutdown(ShutdownArgs shutdownArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("shutdown");
   }
 
   @Override
   public Mono<String> slaveof(String s, int i) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("slaveof");
   }
 
   @Override
   public Mono<String> slaveofNoOne() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("slaveofNoOne");
   }
 
   @Override
   public Flux<Object> slowlogGet() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("slowlogGet");
   }
 
   @Override
   public Flux<Object> slowlogGet(int i) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("slowlogGet");
   }
 
   @Override
   public Mono<Long> slowlogLen() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("slowlogLen");
   }
 
   @Override
   public Mono<String> slowlogReset() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("slowlogReset");
   }
 
   @Override
   public Flux<V> time() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("time");
   }
 
   @Override
   public Mono<Long> sadd(K k, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sadd");
   }
 
   @Override
   public Mono<Long> scard(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("scard");
   }
 
   @Override
   public Flux<V> sdiff(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sdiff");
   }
 
   @Override
   public Mono<Long> sdiff(ValueStreamingChannel<V> valueStreamingChannel, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sdiff");
   }
 
   @Override
   public Mono<Long> sdiffstore(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sdiffstore");
   }
 
   @Override
   public Flux<V> sinter(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sinter");
   }
 
   @Override
   public Mono<Long> sinter(ValueStreamingChannel<V> valueStreamingChannel, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sinter");
   }
 
   @Override
   public Mono<Long> sintercard(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sintercard");
   }
 
   @Override
   public Mono<Long> sintercard(long l, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sintercard");
   }
 
   @Override
   public Mono<Long> sinterstore(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sinterstore");
   }
 
   @Override
   public Mono<Boolean> sismember(K k, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sismember");
   }
 
   @Override
   public Flux<V> smembers(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("smembers");
   }
 
   @Override
   public Mono<Long> smembers(ValueStreamingChannel<V> valueStreamingChannel, K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("smembers");
   }
 
   @Override
   public Flux<Boolean> smismember(K k, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("smismember");
   }
 
   @Override
   public Mono<Boolean> smove(K k, K k1, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("smove");
   }
 
   @Override
   public Mono<V> spop(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("spop");
   }
 
   @Override
   public Flux<V> spop(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("spop");
   }
 
   @Override
   public Mono<V> srandmember(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("srandmember");
   }
 
   @Override
   public Flux<V> srandmember(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("srandmember");
   }
 
   @Override
   public Mono<Long> srandmember(ValueStreamingChannel<V> valueStreamingChannel, K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("srandmember");
   }
 
   @Override
   public Mono<Long> srem(K k, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("srem");
   }
 
   @Override
   public Flux<V> sunion(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sunion");
   }
 
   @Override
   public Mono<Long> sunion(ValueStreamingChannel<V> valueStreamingChannel, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sunion");
   }
 
   @Override
   public Mono<Long> sunionstore(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sunionstore");
   }
 
   @Override
   public Mono<ValueScanCursor<V>> sscan(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sscan");
   }
 
   @Override
   public Mono<ValueScanCursor<V>> sscan(K k, ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sscan");
   }
 
   @Override
   public Mono<ValueScanCursor<V>> sscan(K k, ScanCursor scanCursor, ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sscan");
   }
 
   @Override
   public Mono<ValueScanCursor<V>> sscan(K k, ScanCursor scanCursor) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sscan");
   }
 
   @Override
   public Mono<StreamScanCursor> sscan(ValueStreamingChannel<V> valueStreamingChannel, K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sscan");
   }
 
   @Override
   public Mono<StreamScanCursor> sscan(
       ValueStreamingChannel<V> valueStreamingChannel, K k, ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sscan");
   }
 
   @Override
@@ -2163,341 +2182,343 @@ public class MomentoRedisReactiveClient<K, V>
       K k,
       ScanCursor scanCursor,
       ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sscan");
   }
 
   @Override
   public Mono<StreamScanCursor> sscan(
       ValueStreamingChannel<V> valueStreamingChannel, K k, ScanCursor scanCursor) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("sscan");
   }
 
   @Override
   public Mono<KeyValue<K, ScoredValue<V>>> bzmpop(long l, ZPopArgs zPopArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bzmpop");
   }
 
   @Override
   public Mono<KeyValue<K, List<ScoredValue<V>>>> bzmpop(
       long l, long l1, ZPopArgs zPopArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bzmpop");
   }
 
   @Override
   public Mono<KeyValue<K, ScoredValue<V>>> bzmpop(double v, ZPopArgs zPopArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bzmpop");
   }
 
   @Override
   public Mono<KeyValue<K, List<ScoredValue<V>>>> bzmpop(
       double v, int i, ZPopArgs zPopArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bzmpop");
   }
 
   @Override
   public Mono<KeyValue<K, ScoredValue<V>>> bzpopmin(long l, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bzpopmin");
   }
 
   @Override
   public Mono<KeyValue<K, ScoredValue<V>>> bzpopmin(double v, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bzpopmin");
   }
 
   @Override
   public Mono<KeyValue<K, ScoredValue<V>>> bzpopmax(long l, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bzpopmax");
   }
 
   @Override
   public Mono<KeyValue<K, ScoredValue<V>>> bzpopmax(double v, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bzpopmax");
   }
 
   @Override
   public Mono<Long> zadd(K k, double v, V v1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zadd");
   }
 
   @Override
   public Mono<Long> zadd(K k, Object... objects) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zadd");
   }
 
   @Override
   public Mono<Long> zadd(K k, ScoredValue<V>... scoredValues) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zadd");
   }
 
   @Override
   public Mono<Long> zadd(K k, ZAddArgs zAddArgs, double v, V v1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zadd");
   }
 
   @Override
   public Mono<Long> zadd(K k, ZAddArgs zAddArgs, Object... objects) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zadd");
   }
 
   @Override
   public Mono<Long> zadd(K k, ZAddArgs zAddArgs, ScoredValue<V>... scoredValues) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zadd");
   }
 
   @Override
   public Mono<Double> zaddincr(K k, double v, V v1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zaddincr");
   }
 
   @Override
   public Mono<Double> zaddincr(K k, ZAddArgs zAddArgs, double v, V v1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zaddincr");
   }
 
   @Override
   public Mono<Long> zcard(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zcard");
   }
 
   @Override
   public Mono<Long> zcount(K k, double v, double v1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zcount");
   }
 
   @Override
   public Mono<Long> zcount(K k, String s, String s1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zcount");
   }
 
   @Override
   public Mono<Long> zcount(K k, Range<? extends Number> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zcount");
   }
 
   @Override
   public Flux<V> zdiff(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zdiff");
   }
 
   @Override
   public Mono<Long> zdiffstore(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zdiffstore");
   }
 
   @Override
   public Flux<ScoredValue<V>> zdiffWithScores(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zdiffWithScores");
   }
 
   @Override
   public Mono<Double> zincrby(K k, double v, V v1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zincrby");
   }
 
   @Override
   public Flux<V> zinter(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zinter");
   }
 
   @Override
   public Flux<V> zinter(ZAggregateArgs zAggregateArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zinter");
   }
 
   @Override
   public Mono<Long> zintercard(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zintercard");
   }
 
   @Override
   public Mono<Long> zintercard(long l, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zintercard");
   }
 
   @Override
   public Flux<ScoredValue<V>> zinterWithScores(ZAggregateArgs zAggregateArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zinterWithScores");
   }
 
   @Override
   public Flux<ScoredValue<V>> zinterWithScores(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zinterWithScores");
   }
 
   @Override
   public Mono<Long> zinterstore(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zinterstore");
   }
 
   @Override
   public Mono<Long> zinterstore(K k, ZStoreArgs zStoreArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zinterstore");
   }
 
   @Override
   public Mono<Long> zlexcount(K k, String s, String s1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zlexcount");
   }
 
   @Override
   public Mono<Long> zlexcount(K k, Range<? extends V> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zlexcount");
   }
 
   @Override
   public Mono<List<Double>> zmscore(K k, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zmscore");
   }
 
   @Override
   public Mono<KeyValue<K, ScoredValue<V>>> zmpop(ZPopArgs zPopArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zmpop");
   }
 
   @Override
   public Mono<KeyValue<K, List<ScoredValue<V>>>> zmpop(int i, ZPopArgs zPopArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zmpop");
   }
 
   @Override
   public Mono<ScoredValue<V>> zpopmin(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zpopmin");
   }
 
   @Override
   public Flux<ScoredValue<V>> zpopmin(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zpopmin");
   }
 
   @Override
   public Mono<ScoredValue<V>> zpopmax(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zpopmax");
   }
 
   @Override
   public Flux<ScoredValue<V>> zpopmax(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zpopmax");
   }
 
   @Override
   public Mono<V> zrandmember(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrandmember");
   }
 
   @Override
   public Flux<V> zrandmember(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrandmember");
   }
 
   @Override
   public Mono<ScoredValue<V>> zrandmemberWithScores(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrandmemberWithScores");
   }
 
   @Override
   public Flux<ScoredValue<V>> zrandmemberWithScores(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrandmemberWithScores");
   }
 
   @Override
   public Flux<V> zrange(K k, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrange");
   }
 
   @Override
   public Mono<Long> zrange(ValueStreamingChannel<V> valueStreamingChannel, K k, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrange");
   }
 
   @Override
   public Flux<ScoredValue<V>> zrangeWithScores(K k, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangeWithScores");
   }
 
   @Override
   public Mono<Long> zrangeWithScores(
       ScoredValueStreamingChannel<V> scoredValueStreamingChannel, K k, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangeWithScores");
   }
 
   @Override
   public Flux<V> zrangebylex(K k, String s, String s1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangebylex");
   }
 
   @Override
   public Flux<V> zrangebylex(K k, Range<? extends V> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangebylex");
   }
 
   @Override
   public Flux<V> zrangebylex(K k, String s, String s1, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangebylex");
   }
 
   @Override
   public Flux<V> zrangebylex(K k, Range<? extends V> range, Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangebylex");
   }
 
   @Override
   public Flux<V> zrangebyscore(K k, double v, double v1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangebyscore");
   }
 
   @Override
   public Flux<V> zrangebyscore(K k, String s, String s1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangebyscore");
   }
 
   @Override
   public Flux<V> zrangebyscore(K k, Range<? extends Number> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangebyscore");
   }
 
   @Override
   public Flux<V> zrangebyscore(K k, double v, double v1, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangebyscore");
   }
 
   @Override
   public Flux<V> zrangebyscore(K k, String s, String s1, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangebyscore");
   }
 
   @Override
   public Flux<V> zrangebyscore(K k, Range<? extends Number> range, Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangebyscore");
   }
 
   @Override
   public Mono<Long> zrangebyscore(
       ValueStreamingChannel<V> valueStreamingChannel, K k, double v, double v1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangebyscore");
   }
 
   @Override
   public Mono<Long> zrangebyscore(
       ValueStreamingChannel<V> valueStreamingChannel, K k, String s, String s1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangebycore");
   }
 
   @Override
   public Mono<Long> zrangebyscore(
       ValueStreamingChannel<V> valueStreamingChannel, K k, Range<? extends Number> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangebyscore");
   }
 
   @Override
   public Mono<Long> zrangebyscore(
       ValueStreamingChannel<V> valueStreamingChannel, K k, double v, double v1, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangebyscore");
   }
 
   @Override
   public Mono<Long> zrangebyscore(
       ValueStreamingChannel<V> valueStreamingChannel, K k, String s, String s1, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangebyscore");
   }
 
   @Override
@@ -2506,50 +2527,58 @@ public class MomentoRedisReactiveClient<K, V>
       K k,
       Range<? extends Number> range,
       Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangebyscore");
   }
 
   @Override
   public Flux<ScoredValue<V>> zrangebyscoreWithScores(K k, double v, double v1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrangebyscoreWithScores");
   }
 
   @Override
   public Flux<ScoredValue<V>> zrangebyscoreWithScores(K k, String s, String s1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrangebyscoreWithScores");
   }
 
   @Override
   public Flux<ScoredValue<V>> zrangebyscoreWithScores(K k, Range<? extends Number> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrangebyscoreWithScores");
   }
 
   @Override
   public Flux<ScoredValue<V>> zrangebyscoreWithScores(K k, double v, double v1, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrangebyscoreWithScores");
   }
 
   @Override
   public Flux<ScoredValue<V>> zrangebyscoreWithScores(K k, String s, String s1, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrangebyscoreWithScores");
   }
 
   @Override
   public Flux<ScoredValue<V>> zrangebyscoreWithScores(
       K k, Range<? extends Number> range, Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrangebyscoreWithScores");
   }
 
   @Override
   public Mono<Long> zrangebyscoreWithScores(
       ScoredValueStreamingChannel<V> scoredValueStreamingChannel, K k, double v, double v1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrangebycoreWithScores");
   }
 
   @Override
   public Mono<Long> zrangebyscoreWithScores(
       ScoredValueStreamingChannel<V> scoredValueStreamingChannel, K k, String s, String s1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrangebyscoreWithScores");
   }
 
   @Override
@@ -2557,7 +2586,8 @@ public class MomentoRedisReactiveClient<K, V>
       ScoredValueStreamingChannel<V> scoredValueStreamingChannel,
       K k,
       Range<? extends Number> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrangebyscoreWithScores");
   }
 
   @Override
@@ -2568,7 +2598,8 @@ public class MomentoRedisReactiveClient<K, V>
       double v1,
       long l,
       long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrangebycoreWithScores");
   }
 
   @Override
@@ -2579,7 +2610,8 @@ public class MomentoRedisReactiveClient<K, V>
       String s1,
       long l,
       long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrangebyscoreWithScores");
   }
 
   @Override
@@ -2588,159 +2620,163 @@ public class MomentoRedisReactiveClient<K, V>
       K k,
       Range<? extends Number> range,
       Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrangebyscoreWithScores");
   }
 
   @Override
   public Mono<Long> zrangestore(K k, K k1, Range<Long> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangestore");
   }
 
   @Override
   public Mono<Long> zrangestorebylex(K k, K k1, Range<? extends V> range, Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrangestorebylex");
   }
 
   @Override
   public Mono<Long> zrangestorebyscore(K k, K k1, Range<? extends Number> range, Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrangestorebyscore");
   }
 
   @Override
   public Mono<Long> zrank(K k, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrank");
   }
 
   @Override
   public Mono<ScoredValue<Long>> zrankWithScore(K k, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrankWithScore");
   }
 
   @Override
   public Mono<Long> zrem(K k, V... vs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrem");
   }
 
   @Override
   public Mono<Long> zremrangebylex(K k, String s, String s1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zremrangebylex");
   }
 
   @Override
   public Mono<Long> zremrangebylex(K k, Range<? extends V> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zremrangebylex");
   }
 
   @Override
   public Mono<Long> zremrangebyrank(K k, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zremrangebyrank");
   }
 
   @Override
   public Mono<Long> zremrangebyscore(K k, double v, double v1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zremrangebyscore");
   }
 
   @Override
   public Mono<Long> zremrangebyscore(K k, String s, String s1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zremrangebyscore");
   }
 
   @Override
   public Mono<Long> zremrangebyscore(K k, Range<? extends Number> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zremrangebyscore");
   }
 
   @Override
   public Flux<V> zrevrange(K k, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrange");
   }
 
   @Override
   public Mono<Long> zrevrange(
       ValueStreamingChannel<V> valueStreamingChannel, K k, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrange");
   }
 
   @Override
   public Flux<ScoredValue<V>> zrevrangeWithScores(K k, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrevrangeWithScores");
   }
 
   @Override
   public Mono<Long> zrevrangeWithScores(
       ScoredValueStreamingChannel<V> scoredValueStreamingChannel, K k, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrevrangeWithScores");
   }
 
   @Override
   public Flux<V> zrevrangebylex(K k, Range<? extends V> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrangebylex");
   }
 
   @Override
   public Flux<V> zrevrangebylex(K k, Range<? extends V> range, Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrangebylex");
   }
 
   @Override
   public Flux<V> zrevrangebyscore(K k, double v, double v1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrangebyscore");
   }
 
   @Override
   public Flux<V> zrevrangebyscore(K k, String s, String s1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrangebyscore");
   }
 
   @Override
   public Flux<V> zrevrangebyscore(K k, Range<? extends Number> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrangebyscore");
   }
 
   @Override
   public Flux<V> zrevrangebyscore(K k, double v, double v1, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrangebyscore");
   }
 
   @Override
   public Flux<V> zrevrangebyscore(K k, String s, String s1, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrangebyscore");
   }
 
   @Override
   public Flux<V> zrevrangebyscore(K k, Range<? extends Number> range, Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrangebyscore");
   }
 
   @Override
   public Mono<Long> zrevrangebyscore(
       ValueStreamingChannel<V> valueStreamingChannel, K k, double v, double v1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrangebyscore");
   }
 
   @Override
   public Mono<Long> zrevrangebyscore(
       ValueStreamingChannel<V> valueStreamingChannel, K k, String s, String s1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrangebyscore");
   }
 
   @Override
   public Mono<Long> zrevrangebyscore(
       ValueStreamingChannel<V> valueStreamingChannel, K k, Range<? extends Number> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrangebyscore");
   }
 
   @Override
   public Mono<Long> zrevrangebyscore(
       ValueStreamingChannel<V> valueStreamingChannel, K k, double v, double v1, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrangebyscore");
   }
 
   @Override
   public Mono<Long> zrevrangebyscore(
       ValueStreamingChannel<V> valueStreamingChannel, K k, String s, String s1, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrangebyscore");
   }
 
   @Override
@@ -2749,52 +2785,60 @@ public class MomentoRedisReactiveClient<K, V>
       K k,
       Range<? extends Number> range,
       Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrangebyscore");
   }
 
   @Override
   public Flux<ScoredValue<V>> zrevrangebyscoreWithScores(K k, double v, double v1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrevrangebyscoreWithScores");
   }
 
   @Override
   public Flux<ScoredValue<V>> zrevrangebyscoreWithScores(K k, String s, String s1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrevrangebyscoreWithScores");
   }
 
   @Override
   public Flux<ScoredValue<V>> zrevrangebyscoreWithScores(K k, Range<? extends Number> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrevrangebyscoreWithScores");
   }
 
   @Override
   public Flux<ScoredValue<V>> zrevrangebyscoreWithScores(
       K k, double v, double v1, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrevrangebyscoreWithScores");
   }
 
   @Override
   public Flux<ScoredValue<V>> zrevrangebyscoreWithScores(
       K k, String s, String s1, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrevrangebyscoreWithScores");
   }
 
   @Override
   public Flux<ScoredValue<V>> zrevrangebyscoreWithScores(
       K k, Range<? extends Number> range, Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrevrangebyscoreWithScores");
   }
 
   @Override
   public Mono<Long> zrevrangebyscoreWithScores(
       ScoredValueStreamingChannel<V> scoredValueStreamingChannel, K k, double v, double v1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrevrangebyscoreWithScores");
   }
 
   @Override
   public Mono<Long> zrevrangebyscoreWithScores(
       ScoredValueStreamingChannel<V> scoredValueStreamingChannel, K k, String s, String s1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrevrangebyscoreWithScores");
   }
 
   @Override
@@ -2802,7 +2846,8 @@ public class MomentoRedisReactiveClient<K, V>
       ScoredValueStreamingChannel<V> scoredValueStreamingChannel,
       K k,
       Range<? extends Number> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrevrangebyscoreWithScores");
   }
 
   @Override
@@ -2813,7 +2858,8 @@ public class MomentoRedisReactiveClient<K, V>
       double v1,
       long l,
       long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrevrangebyscoreWithScores");
   }
 
   @Override
@@ -2824,7 +2870,8 @@ public class MomentoRedisReactiveClient<K, V>
       String s1,
       long l,
       long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrevrangebyscoreWithScores");
   }
 
   @Override
@@ -2833,64 +2880,67 @@ public class MomentoRedisReactiveClient<K, V>
       K k,
       Range<? extends Number> range,
       Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrevrangebyscoreWithScores");
   }
 
   @Override
   public Mono<Long> zrevrangestore(K k, K k1, Range<Long> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrangestore");
   }
 
   @Override
   public Mono<Long> zrevrangestorebylex(K k, K k1, Range<? extends V> range, Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrevrangestorebylex");
   }
 
   @Override
   public Mono<Long> zrevrangestorebyscore(K k, K k1, Range<? extends Number> range, Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "zrevrangestorebyscore");
   }
 
   @Override
   public Mono<Long> zrevrank(K k, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrank");
   }
 
   @Override
   public Mono<ScoredValue<Long>> zrevrankWithScore(K k, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zrevrankWithScore");
   }
 
   @Override
   public Mono<ScoredValueScanCursor<V>> zscan(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zscan");
   }
 
   @Override
   public Mono<ScoredValueScanCursor<V>> zscan(K k, ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zscan");
   }
 
   @Override
   public Mono<ScoredValueScanCursor<V>> zscan(K k, ScanCursor scanCursor, ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zscan");
   }
 
   @Override
   public Mono<ScoredValueScanCursor<V>> zscan(K k, ScanCursor scanCursor) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zscan");
   }
 
   @Override
   public Mono<StreamScanCursor> zscan(
       ScoredValueStreamingChannel<V> scoredValueStreamingChannel, K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zscan");
   }
 
   @Override
   public Mono<StreamScanCursor> zscan(
       ScoredValueStreamingChannel<V> scoredValueStreamingChannel, K k, ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zscan");
   }
 
   @Override
@@ -2899,289 +2949,290 @@ public class MomentoRedisReactiveClient<K, V>
       K k,
       ScanCursor scanCursor,
       ScanArgs scanArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zscan");
   }
 
   @Override
   public Mono<StreamScanCursor> zscan(
       ScoredValueStreamingChannel<V> scoredValueStreamingChannel, K k, ScanCursor scanCursor) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zscan");
   }
 
   @Override
   public Mono<Double> zscore(K k, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zscore");
   }
 
   @Override
   public Flux<V> zunion(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zunion");
   }
 
   @Override
   public Flux<V> zunion(ZAggregateArgs zAggregateArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zunion");
   }
 
   @Override
   public Flux<ScoredValue<V>> zunionWithScores(ZAggregateArgs zAggregateArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zunionWithScores");
   }
 
   @Override
   public Flux<ScoredValue<V>> zunionWithScores(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zunionWithScores");
   }
 
   @Override
   public Mono<Long> zunionstore(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zunionstore");
   }
 
   @Override
   public Mono<Long> zunionstore(K k, ZStoreArgs zStoreArgs, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("zunionstore");
   }
 
   @Override
   public Mono<Long> xack(K k, K k1, String... strings) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xack");
   }
 
   @Override
   public Mono<String> xadd(K k, Map<K, V> map) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xadd");
   }
 
   @Override
   public Mono<String> xadd(K k, XAddArgs xAddArgs, Map<K, V> map) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xadd");
   }
 
   @Override
   public Mono<String> xadd(K k, Object... objects) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xadd");
   }
 
   @Override
   public Mono<String> xadd(K k, XAddArgs xAddArgs, Object... objects) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xadd");
   }
 
   @Override
   public Mono<ClaimedMessages<K, V>> xautoclaim(K k, XAutoClaimArgs<K> xAutoClaimArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xautoclaim");
   }
 
   @Override
   public Flux<StreamMessage<K, V>> xclaim(K k, Consumer<K> consumer, long l, String... strings) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xclaim");
   }
 
   @Override
   public Flux<StreamMessage<K, V>> xclaim(
       K k, Consumer<K> consumer, XClaimArgs xClaimArgs, String... strings) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xclaim");
   }
 
   @Override
   public Mono<Long> xdel(K k, String... strings) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xdel");
   }
 
   @Override
   public Mono<String> xgroupCreate(XReadArgs.StreamOffset<K> streamOffset, K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xgroupCreate");
   }
 
   @Override
   public Mono<String> xgroupCreate(
       XReadArgs.StreamOffset<K> streamOffset, K k, XGroupCreateArgs xGroupCreateArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xgroupCreate");
   }
 
   @Override
   public Mono<Boolean> xgroupCreateconsumer(K k, Consumer<K> consumer) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException(
+        "xgroupCreateconsumer");
   }
 
   @Override
   public Mono<Long> xgroupDelconsumer(K k, Consumer<K> consumer) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xgroupDelconsumer");
   }
 
   @Override
   public Mono<Boolean> xgroupDestroy(K k, K k1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xgroupDestroy");
   }
 
   @Override
   public Mono<String> xgroupSetid(XReadArgs.StreamOffset<K> streamOffset, K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xgroupSetid");
   }
 
   @Override
   public Flux<Object> xinfoStream(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xinfoStream");
   }
 
   @Override
   public Flux<Object> xinfoGroups(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xinfoGroups");
   }
 
   @Override
   public Flux<Object> xinfoConsumers(K k, K k1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xinfoConsumers");
   }
 
   @Override
   public Mono<Long> xlen(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xlen");
   }
 
   @Override
   public Mono<PendingMessages> xpending(K k, K k1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xpending");
   }
 
   @Override
   public Flux<PendingMessage> xpending(K k, K k1, Range<String> range, Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xpending");
   }
 
   @Override
   public Flux<PendingMessage> xpending(
       K k, Consumer<K> consumer, Range<String> range, Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xpending");
   }
 
   @Override
   public Flux<PendingMessage> xpending(K k, XPendingArgs<K> xPendingArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xpending");
   }
 
   @Override
   public Flux<StreamMessage<K, V>> xrange(K k, Range<String> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xrange");
   }
 
   @Override
   public Flux<StreamMessage<K, V>> xrange(K k, Range<String> range, Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xrange");
   }
 
   @Override
   public Flux<StreamMessage<K, V>> xread(XReadArgs.StreamOffset<K>... streamOffsets) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xread");
   }
 
   @Override
   public Flux<StreamMessage<K, V>> xread(
       XReadArgs xReadArgs, XReadArgs.StreamOffset<K>... streamOffsets) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xread");
   }
 
   @Override
   public Flux<StreamMessage<K, V>> xreadgroup(
       Consumer<K> consumer, XReadArgs.StreamOffset<K>... streamOffsets) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xreadgroup");
   }
 
   @Override
   public Flux<StreamMessage<K, V>> xreadgroup(
       Consumer<K> consumer, XReadArgs xReadArgs, XReadArgs.StreamOffset<K>... streamOffsets) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xreadgroup");
   }
 
   @Override
   public Flux<StreamMessage<K, V>> xrevrange(K k, Range<String> range) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xrevrange");
   }
 
   @Override
   public Flux<StreamMessage<K, V>> xrevrange(K k, Range<String> range, Limit limit) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xrevrange");
   }
 
   @Override
   public Mono<Long> xtrim(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xtrim");
   }
 
   @Override
   public Mono<Long> xtrim(K k, boolean b, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xtrim");
   }
 
   @Override
   public Mono<Long> xtrim(K k, XTrimArgs xTrimArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("xtrim");
   }
 
   @Override
   public Mono<Long> append(K k, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("append");
   }
 
   @Override
   public Mono<Long> bitcount(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bitcount");
   }
 
   @Override
   public Mono<Long> bitcount(K k, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bitcount");
   }
 
   @Override
   public Flux<Value<Long>> bitfield(K k, BitFieldArgs bitFieldArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bitfield");
   }
 
   @Override
   public Mono<Long> bitpos(K k, boolean b) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bitpos");
   }
 
   @Override
   public Mono<Long> bitpos(K k, boolean b, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bitpos");
   }
 
   @Override
   public Mono<Long> bitpos(K k, boolean b, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bitpos");
   }
 
   @Override
   public Mono<Long> bitopAnd(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bitopAnd");
   }
 
   @Override
   public Mono<Long> bitopNot(K k, K k1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bitopNot");
   }
 
   @Override
   public Mono<Long> bitopOr(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bitopOr");
   }
 
   @Override
   public Mono<Long> bitopXor(K k, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("bitopXor");
   }
 
   @Override
   public Mono<Long> decr(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("decr");
   }
 
   @Override
   public Mono<Long> decrby(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("decrby");
   }
 
   @Override
@@ -3207,62 +3258,62 @@ public class MomentoRedisReactiveClient<K, V>
 
   @Override
   public Mono<Long> getbit(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("getbit");
   }
 
   @Override
   public Mono<V> getdel(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("getdel");
   }
 
   @Override
   public Mono<V> getex(K k, GetExArgs getExArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("getex");
   }
 
   @Override
   public Mono<V> getrange(K k, long l, long l1) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("getrange");
   }
 
   @Override
   public Mono<V> getset(K k, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("getset");
   }
 
   @Override
   public Mono<Long> incr(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("incr");
   }
 
   @Override
   public Mono<Long> incrby(K k, long l) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("incrby");
   }
 
   @Override
   public Mono<Double> incrbyfloat(K k, double v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("incrbyfloat");
   }
 
   @Override
   public Flux<KeyValue<K, V>> mget(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("mget");
   }
 
   @Override
   public Mono<Long> mget(KeyValueStreamingChannel<K, V> keyValueStreamingChannel, K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("mget");
   }
 
   @Override
   public Mono<String> mset(Map<K, V> map) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("mset");
   }
 
   @Override
   public Mono<Boolean> msetnx(Map<K, V> map) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("msetnx");
   }
 
   @Override
@@ -3286,76 +3337,76 @@ public class MomentoRedisReactiveClient<K, V>
 
   @Override
   public Mono<String> set(K k, V v, SetArgs setArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("set");
   }
 
   @Override
   public Mono<V> setGet(K k, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("setGet");
   }
 
   @Override
   public Mono<V> setGet(K k, V v, SetArgs setArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("setGet");
   }
 
   @Override
   public Mono<Long> setbit(K k, long l, int i) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("setbit");
   }
 
   @Override
   public Mono<String> setex(K k, long l, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("setex");
   }
 
   @Override
   public Mono<String> psetex(K k, long l, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("psetex");
   }
 
   @Override
   public Mono<Boolean> setnx(K k, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("setnx");
   }
 
   @Override
   public Mono<Long> setrange(K k, long l, V v) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("setrange");
   }
 
   @Override
   public Mono<StringMatchResult> stralgoLcs(StrAlgoArgs strAlgoArgs) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("stralgoLcs");
   }
 
   @Override
   public Mono<Long> strlen(K k) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("strlen");
   }
 
   @Override
   public Mono<String> discard() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("discard");
   }
 
   @Override
   public Mono<TransactionResult> exec() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("exec");
   }
 
   @Override
   public Mono<String> multi() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("multi");
   }
 
   @Override
   public Mono<String> watch(K... ks) {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("watch");
   }
 
   @Override
   public Mono<String> unwatch() {
-    return null;
+    throw MomentoToLettuceExceptionMapper.createCommandNotImplementedException("unwatch");
   }
 }

--- a/src/test/java/momento/lettuce/UnimplementedCommandTest.java
+++ b/src/test/java/momento/lettuce/UnimplementedCommandTest.java
@@ -1,0 +1,20 @@
+package momento.lettuce;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+final class UnimplementedCommandTest extends BaseTestClass {
+  @Test
+  public void testZunion() {
+    if (isRedisTest()) {
+      return;
+    }
+
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> {
+          client.zunion("key1", "key2");
+        });
+  }
+}


### PR DESCRIPTION
Updates the Momento client to throw an exception on unimplemented
commands. Because a few of these can be don't-cares, we do not throw
exceptions on them. For most of them we do though.

Note that the `MomentoRedisReactiveCommands` interface still provides
an exhaustive list of implemented commands.
