### PR TITLE
chore: update group id

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,7 @@ plugins {
     id("com.diffplug.spotless") version "5.15.1"
 }
 
-// TODO replace with etsablished group id
-group = "momento.lettuce"
+group = "software.momento.java"
 version = "0.1.0"
 
 repositories {


### PR DESCRIPTION
Update the group id to what we will publish under Maven Central. Because we already used the package `momento.lettuce`, we do not need to adjust that.
