### PR TITLE
chore: build target should only build not test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 
 ## Build the project
 build:
-	./gradlew build
+	./gradlew assemble
 
 ## Run all the tests
 test: test-momento test-redis


### PR DESCRIPTION
The gradlew task `build` actually builds and tests. We want to just
build for this makefile target, which corresponds to `assemble`.
