### PR TITLE
ci: set project name in one place

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             from(components["java"])
             groupId = group.toString()
-            artifactId = "momento-lettuce"
+            artifactId = project.name
             version = project.version.toString()
 
             pom {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,2 @@
-rootProject.name = "momento-java-lettuce-client"
+rootProject.name = "momento-lettuce"
 


### PR DESCRIPTION
Previously the project name didn't match the artifact id, which
resulted in Sonatype reporting an incorrect description. We update the
project name and refer to that in the publish block.
