### PR TITLE
ci: close and release staging repository on release

### DIFF
--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -54,5 +54,4 @@ jobs:
         ORG_GRADLE_PROJECT_version: ${{ needs.release.outputs.version }}
       uses: gradle/gradle-build-action@v2
       with:
-        # Note that this will require manual release from Sonatype
-        arguments: publishToSonatype closeSonatypeStagingRepository
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository


### PR DESCRIPTION
Previously we did not release on publish to test the first
release. Now that we have verified the release process once, we can
immediately release.
