### PR TITLE
chore: remove unused event scheduler

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -64,6 +64,6 @@ jobs:
       run: make build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/src/main/java/momento/lettuce/MomentoRedisReactiveClient.java
+++ b/src/main/java/momento/lettuce/MomentoRedisReactiveClient.java
@@ -112,7 +112,6 @@ public class MomentoRedisReactiveClient<K, V>
   private final CacheClient client;
   private final String cacheName;
   private final RedisCodecByteArrayConverter<K, V> codec;
-  private volatile EventExecutorGroup scheduler;
 
   /**
    * Creates a new {@link MomentoRedisReactiveClient}.
@@ -125,7 +124,6 @@ public class MomentoRedisReactiveClient<K, V>
     this.client = client;
     this.cacheName = cacheName;
     this.codec = new RedisCodecByteArrayConverter<>(codec);
-    this.scheduler = ImmediateEventExecutor.INSTANCE;
   }
 
   /**


### PR DESCRIPTION
The event scheduler isn't used directly in the Momento
implementation. When a user wants to control thread resource
usage, that will be a concern on the Momento client and would
require Momento config updates.