### PR TITLE
ci: revert to previous sonatype release command

### DIFF
--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -54,4 +54,4 @@ jobs:
         ORG_GRADLE_PROJECT_version: ${{ needs.release.outputs.version }}
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        arguments: publishToSonatype closeSonatypeStagingRepository


### PR DESCRIPTION
In order to rule out a release workflow bug, we try the previously
working command.
