### PR TITLE
ci: fix missing needs property on release workflow

### DIFF
--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -30,6 +30,7 @@ jobs:
         run: echo "release=${{ steps.semrel.outputs.version }}" >> $GITHUB_OUTPUT
 
   publish:
+    needs: [ release ]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Previously we forgot to add the needs property in order to access the
version.
