### PR TITLE
ci: fix release version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 }
 
 group = "software.momento.java"
-version = "0.1.0"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
No longer set the version in the build.gradle.kts. Otherwise we cannot
override with the env var in CI.
