### PR TITLE
ci: on release use `closeAndRelease`

### DIFF
--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -55,4 +55,4 @@ jobs:
         ORG_GRADLE_PROJECT_version: ${{ needs.release.outputs.version }}
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: publishToSonatype closeSonatypeStagingRepository
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository


### PR DESCRIPTION
Previously we used `closeSonatypeStagingRepository` for debugging. We
will use the common `closeAndRelease`* instead.
